### PR TITLE
(maint) Add tracker API format support for real-time draft data

### DIFF
--- a/config.json.example
+++ b/config.json.example
@@ -14,6 +14,11 @@
       "adam": {
         "sheet_name": "Adam",
         "sheet_range": "Adam!A1:T20"
+      },
+      "tracker": {
+        "base_url": "http://localhost:8175",
+        "sheet_name": "N/A",
+        "sheet_range": "N/A"
       }
     }
   },

--- a/src/services/tracker_api_service.py
+++ b/src/services/tracker_api_service.py
@@ -1,0 +1,80 @@
+"""HTTP API service for tracker draft data."""
+
+import logging
+from typing import Dict, List
+
+import aiohttp
+
+logger = logging.getLogger(__name__)
+
+
+class TrackerAPIService:
+    """Service for making HTTP calls to the tracker API."""
+
+    def __init__(self, base_url: str = "http://localhost:8175"):
+        self.base_url = base_url.rstrip("/")
+        self.timeout = aiohttp.ClientTimeout(total=30)
+
+    async def get_draft_state(self) -> Dict:
+        """Fetch draft state from tracker API.
+
+        Returns:
+            Dict with teams array and other draft data
+
+        Raises:
+            aiohttp.ClientError: If API call fails
+        """
+        url = f"{self.base_url}/api/v1/draft-state"
+        logger.info(f"Fetching draft state from {url}")
+
+        async with aiohttp.ClientSession(timeout=self.timeout) as session:
+            async with session.get(url) as response:
+                response.raise_for_status()
+                data = await response.json()
+                logger.info(
+                    f"Successfully fetched draft state with {len(data.get('teams', []))} teams"
+                )
+                return data
+
+    async def get_owner_info(self, owner_id: int) -> Dict:
+        """Fetch owner information by owner_id.
+
+        Args:
+            owner_id: The owner ID to lookup
+
+        Returns:
+            Dict with owner_name and team_name
+
+        Raises:
+            aiohttp.ClientError: If API call fails
+        """
+        url = f"{self.base_url}/api/v1/owners/{owner_id}"
+        logger.debug(f"Fetching owner info for ID {owner_id} from {url}")
+
+        async with aiohttp.ClientSession(timeout=self.timeout) as session:
+            async with session.get(url) as response:
+                response.raise_for_status()
+                data = await response.json()
+                logger.debug(
+                    f"Successfully fetched owner info: {data.get('owner_name')}"
+                )
+                return data
+
+    async def get_all_players(self) -> List[Dict]:
+        """Fetch all players from tracker API.
+
+        Returns:
+            List of player dictionaries with id, first_name, last_name, team, position
+
+        Raises:
+            aiohttp.ClientError: If API call fails
+        """
+        url = f"{self.base_url}/api/v1/players"
+        logger.info(f"Fetching all players from {url}")
+
+        async with aiohttp.ClientSession(timeout=self.timeout) as session:
+            async with session.get(url) as response:
+                response.raise_for_status()
+                data = await response.json()
+                logger.info(f"Successfully fetched {len(data)} players")
+                return data

--- a/src/services/tracker_draft_parser.py
+++ b/src/services/tracker_draft_parser.py
@@ -1,0 +1,135 @@
+"""Parser for tracker API draft format."""
+
+import logging
+from typing import Dict, List, Optional
+
+from src.models.draft_pick import DraftPick
+from src.models.draft_state_simple import DraftState
+from src.models.injury_status import InjuryStatus
+from src.models.player_simple import Player
+from src.services.sheet_parser import ParseError, SheetParser
+from src.services.tracker_api_service import TrackerAPIService
+
+logger = logging.getLogger(__name__)
+
+
+class TrackerDraftParser(SheetParser):
+    """Parser for tracker API draft format.
+
+    This parser fetches draft data from the tracker API endpoints instead
+    of Google Sheets, but converts the data to the same DraftState format
+    for compatibility with existing tools.
+    """
+
+    def __init__(self, base_url: str = "http://localhost:8175"):
+        self.api_service = TrackerAPIService(base_url)
+
+    def detect_format(self, sheet_data: List[List]) -> bool:
+        """For tracker format, we don't use sheet_data detection.
+
+        Args:
+            sheet_data: Ignored for tracker format
+
+        Returns:
+            Always True since this parser is explicitly chosen via config
+        """
+        # Tracker format is explicitly chosen via configuration,
+        # not auto-detected from sheet data
+        return True
+
+    async def parse_draft_data(
+        self, sheet_data: List[List], rankings_cache: Optional[Dict] = None
+    ) -> DraftState:
+        """Parse draft data from tracker API instead of sheet_data.
+
+        Args:
+            sheet_data: Ignored for tracker format (we use API instead)
+            rankings_cache: Optional rankings cache (not used for tracker)
+
+        Returns:
+            DraftState object with picks and team information
+
+        Raises:
+            ParseError: If API calls fail or data is malformed
+        """
+        try:
+            logger.info("Parsing draft data from tracker API")
+
+            # Fetch all required data from API
+            draft_state_raw = await self.api_service.get_draft_state()
+            players_raw = await self.api_service.get_all_players()
+
+            # Build player lookup dictionary
+            player_lookup = {p["id"]: p for p in players_raw}
+            logger.info(f"Built player lookup with {len(player_lookup)} players")
+
+            # Extract teams from draft state
+            teams_raw = draft_state_raw.get("teams", [])
+            if not teams_raw:
+                logger.warning("No teams found in draft state")
+                return DraftState(picks=[], teams=[])
+
+            # Get unique owner IDs and fetch owner/team info
+            owner_ids = list(set(team["owner_id"] for team in teams_raw))
+
+            # Fetch all owner details (includes both owner_name and team_name)
+            owner_details = {}
+            for owner_id in owner_ids:
+                owner_info = await self.api_service.get_owner_info(owner_id)
+                owner_details[owner_id] = {
+                    "owner_name": owner_info["owner_name"],
+                    "team_name": owner_info["team_name"],
+                }
+
+            # Build picks and teams lists
+            all_picks = []
+            teams_info = []
+
+            for team_data in teams_raw:
+                owner_id = team_data["owner_id"]
+                owner_detail = owner_details.get(owner_id, {})
+                owner_name = owner_detail.get("owner_name", f"Owner {owner_id}")
+                team_name = owner_detail.get("team_name", owner_name)
+
+                # Add team info
+                teams_info.append({"owner": owner_name, "team": team_name})
+
+                # Process picks for this team
+                picks = team_data.get("picks", [])
+                for pick_data in picks:
+                    player_id = pick_data["player_id"]
+
+                    # Look up player info
+                    player_info = player_lookup.get(player_id)
+                    if not player_info:
+                        logger.warning(
+                            f"Player ID {player_id} not found in players list"
+                        )
+                        continue
+
+                    # Create Player object
+                    player = Player(
+                        name=f"{player_info['first_name']} {player_info['last_name']}",
+                        team=player_info["team"],
+                        position=player_info["position"],
+                        bye_week=0,  # Not available from tracker API
+                        ranking=0,  # Not available from tracker API
+                        projected_points=0.0,  # Not available from tracker API
+                        injury_status=InjuryStatus.HEALTHY,  # Default to healthy
+                        notes="",  # No notes from tracker API
+                    )
+
+                    # Create DraftPick object
+                    draft_pick = DraftPick(player=player, owner=owner_name)
+
+                    all_picks.append(draft_pick)
+
+            logger.info(
+                f"Successfully parsed {len(all_picks)} picks for {len(teams_info)} teams"
+            )
+
+            return DraftState(picks=all_picks, teams=teams_info)
+
+        except Exception as e:
+            logger.error(f"Error parsing tracker draft data: {str(e)}")
+            raise ParseError(f"Failed to parse tracker draft data: {str(e)}") from e

--- a/tests/services/test_tracker_api_service.py
+++ b/tests/services/test_tracker_api_service.py
@@ -1,0 +1,199 @@
+"""Tests for the tracker API service."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import aiohttp
+import pytest
+
+from src.services.tracker_api_service import TrackerAPIService
+
+
+@pytest.fixture
+def api_service():
+    """Create a TrackerAPIService instance."""
+    return TrackerAPIService()
+
+
+@pytest.fixture
+def mock_draft_state_json():
+    """Mock JSON response from draft-state endpoint."""
+    return {
+        "teams": [
+            {"owner_id": 1, "budget_remaining": 168, "picks": []},
+            {"owner_id": 2, "budget_remaining": 200, "picks": []},
+        ],
+        "next_to_nominate": 1,
+        "version": 1,
+    }
+
+
+@pytest.fixture
+def mock_owner_json():
+    """Mock JSON response from owner endpoint."""
+    return {"id": 1, "owner_name": "Giles", "team_name": "The Watchers Council"}
+
+
+@pytest.fixture
+def mock_players_json():
+    """Mock JSON response from players endpoint."""
+    return [
+        {
+            "id": 1,
+            "first_name": "Patrick",
+            "last_name": "Mahomes",
+            "team": "KC",
+            "position": "QB",
+        },
+        {
+            "id": 2,
+            "first_name": "Josh",
+            "last_name": "Allen",
+            "team": "BUF",
+            "position": "QB",
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_get_draft_state(api_service, mock_draft_state_json):
+    """Test fetching draft state from API."""
+
+    with patch(
+        "src.services.tracker_api_service.aiohttp.ClientSession"
+    ) as mock_session_class:
+        mock_session = MagicMock()
+        mock_session_class.return_value.__aenter__.return_value = mock_session
+
+        mock_response = MagicMock()
+        mock_response.json = AsyncMock(return_value=mock_draft_state_json)
+        mock_response.raise_for_status = MagicMock()
+
+        # Create a mock for the get() method that returns an async context manager
+        mock_get = MagicMock()
+        mock_get.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_get.__aexit__ = AsyncMock()
+        mock_session.get.return_value = mock_get
+
+        result = await api_service.get_draft_state()
+
+        assert result == mock_draft_state_json
+        assert len(result["teams"]) == 2
+        mock_session.get.assert_called_once_with(
+            "http://localhost:8175/api/v1/draft-state"
+        )
+
+
+@pytest.mark.asyncio
+async def test_get_owner_info(api_service, mock_owner_json):
+    """Test fetching owner information from API."""
+
+    with patch(
+        "src.services.tracker_api_service.aiohttp.ClientSession"
+    ) as mock_session_class:
+        mock_session = MagicMock()
+        mock_session_class.return_value.__aenter__.return_value = mock_session
+
+        mock_response = MagicMock()
+        mock_response.json = AsyncMock(return_value=mock_owner_json)
+        mock_response.raise_for_status = MagicMock()
+
+        mock_get = MagicMock()
+        mock_get.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_get.__aexit__ = AsyncMock()
+        mock_session.get.return_value = mock_get
+
+        result = await api_service.get_owner_info(1)
+
+        assert result == mock_owner_json
+        assert result["owner_name"] == "Giles"
+        assert result["team_name"] == "The Watchers Council"
+        mock_session.get.assert_called_once_with(
+            "http://localhost:8175/api/v1/owners/1"
+        )
+
+
+@pytest.mark.asyncio
+async def test_get_all_players(api_service, mock_players_json):
+    """Test fetching all players from API."""
+
+    with patch(
+        "src.services.tracker_api_service.aiohttp.ClientSession"
+    ) as mock_session_class:
+        mock_session = MagicMock()
+        mock_session_class.return_value.__aenter__.return_value = mock_session
+
+        mock_response = MagicMock()
+        mock_response.json = AsyncMock(return_value=mock_players_json)
+        mock_response.raise_for_status = MagicMock()
+
+        mock_get = MagicMock()
+        mock_get.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_get.__aexit__ = AsyncMock()
+        mock_session.get.return_value = mock_get
+
+        result = await api_service.get_all_players()
+
+        assert result == mock_players_json
+        assert len(result) == 2
+        assert result[0]["first_name"] == "Patrick"
+        mock_session.get.assert_called_once_with("http://localhost:8175/api/v1/players")
+
+
+@pytest.mark.asyncio
+async def test_custom_base_url():
+    """Test that custom base URL is used correctly."""
+    custom_url = "http://tracker.example.com:8080"
+    api_service = TrackerAPIService(base_url=custom_url)
+
+    with patch(
+        "src.services.tracker_api_service.aiohttp.ClientSession"
+    ) as mock_session_class:
+        mock_session = MagicMock()
+        mock_session_class.return_value.__aenter__.return_value = mock_session
+
+        mock_response = MagicMock()
+        mock_response.json = AsyncMock(return_value={"teams": []})
+        mock_response.raise_for_status = MagicMock()
+
+        mock_get = MagicMock()
+        mock_get.__aenter__ = AsyncMock(return_value=mock_response)
+        mock_get.__aexit__ = AsyncMock()
+        mock_session.get.return_value = mock_get
+
+        await api_service.get_draft_state()
+
+        mock_session.get.assert_called_once_with(
+            "http://tracker.example.com:8080/api/v1/draft-state"
+        )
+
+
+@pytest.mark.asyncio
+async def test_api_error_handling():
+    """Test that API errors are properly raised."""
+    api_service = TrackerAPIService()
+
+    with patch(
+        "src.services.tracker_api_service.aiohttp.ClientSession"
+    ) as mock_session_class:
+        mock_session = MagicMock()
+        mock_session_class.return_value.__aenter__.return_value = mock_session
+
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock(
+            side_effect=aiohttp.ClientResponseError(
+                request_info=MagicMock(), history=(), status=404
+            )
+        )
+
+        # Make __aenter__ raise the exception when the response tries to check status
+        async def raise_error():
+            mock_response.raise_for_status()
+            return mock_response
+
+        mock_get = MagicMock()
+        mock_get.__aenter__ = AsyncMock(side_effect=raise_error)
+        mock_get.__aexit__ = AsyncMock()
+        mock_session.get.return_value = mock_get
+
+        with pytest.raises(aiohttp.ClientResponseError):
+            await api_service.get_draft_state()

--- a/tests/services/test_tracker_draft_parser.py
+++ b/tests/services/test_tracker_draft_parser.py
@@ -1,0 +1,226 @@
+"""Tests for the tracker draft parser."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from src.models.draft_state_simple import DraftState
+from src.services.tracker_draft_parser import TrackerDraftParser
+
+
+@pytest.fixture
+def mock_draft_state_response():
+    """Mock response from /api/v1/draft-state endpoint."""
+    return {
+        "teams": [
+            {
+                "owner_id": 1,
+                "budget_remaining": 168,
+                "picks": [
+                    {"pick_id": 1, "player_id": 4427366, "owner_id": 1, "price": 13},
+                    {"pick_id": 2, "player_id": 4426515, "owner_id": 1, "price": 12},
+                ],
+            },
+            {
+                "owner_id": 2,
+                "budget_remaining": 111,
+                "picks": [
+                    {"pick_id": 3, "player_id": 3117251, "owner_id": 2, "price": 56},
+                ],
+            },
+        ],
+        "next_to_nominate": 1,
+        "version": 33,
+    }
+
+
+@pytest.fixture
+def mock_players_response():
+    """Mock response from /api/v1/players endpoint."""
+    return [
+        {
+            "id": 4427366,
+            "first_name": "Breece",
+            "last_name": "Hall",
+            "team": "NYJ",
+            "position": "RB",
+        },
+        {
+            "id": 4426515,
+            "first_name": "Justin",
+            "last_name": "Jefferson",
+            "team": "MIN",
+            "position": "WR",
+        },
+        {
+            "id": 3117251,
+            "first_name": "CeeDee",
+            "last_name": "Lamb",
+            "team": "DAL",
+            "position": "WR",
+        },
+    ]
+
+
+@pytest.fixture
+def mock_owner_responses():
+    """Mock responses from /api/v1/owners/{id} endpoint."""
+    return {
+        1: {"id": 1, "owner_name": "Buffy", "team_name": "Sunnydale Slayers"},
+        2: {"id": 2, "owner_name": "Willow", "team_name": "Dark Phoenix Rising"},
+    }
+
+
+@pytest.mark.asyncio
+async def test_tracker_parser_parse_draft_data(
+    mock_draft_state_response, mock_players_response, mock_owner_responses
+):
+    """Test that tracker parser correctly fetches and parses API data."""
+    parser = TrackerDraftParser()
+
+    # Mock the API service methods
+    with patch.object(
+        parser.api_service, "get_draft_state", new_callable=AsyncMock
+    ) as mock_get_draft:
+        with patch.object(
+            parser.api_service, "get_all_players", new_callable=AsyncMock
+        ) as mock_get_players:
+            with patch.object(
+                parser.api_service, "get_owner_info", new_callable=AsyncMock
+            ) as mock_get_owner:
+
+                # Set up mock return values
+                mock_get_draft.return_value = mock_draft_state_response
+                mock_get_players.return_value = mock_players_response
+
+                # Mock owner info calls
+                async def owner_side_effect(owner_id):
+                    return mock_owner_responses[owner_id]
+
+                mock_get_owner.side_effect = owner_side_effect
+
+                # Parse the data
+                result = await parser.parse_draft_data([], None)
+
+                # Verify result is a DraftState
+                assert isinstance(result, DraftState)
+
+                # Check teams
+                assert len(result.teams) == 2
+                assert result.teams[0]["owner"] == "Buffy"
+                assert result.teams[0]["team"] == "Sunnydale Slayers"
+                assert result.teams[1]["owner"] == "Willow"
+                assert result.teams[1]["team"] == "Dark Phoenix Rising"
+
+                # Check picks
+                assert len(result.picks) == 3
+
+                # First pick (Breece Hall)
+                assert result.picks[0].player.name == "Breece Hall"
+                assert result.picks[0].player.team == "NYJ"
+                assert result.picks[0].player.position == "RB"
+                assert result.picks[0].owner == "Buffy"
+
+                # Second pick (Justin Jefferson)
+                assert result.picks[1].player.name == "Justin Jefferson"
+                assert result.picks[1].player.team == "MIN"
+                assert result.picks[1].player.position == "WR"
+                assert result.picks[1].owner == "Buffy"
+
+                # Third pick (CeeDee Lamb)
+                assert result.picks[2].player.name == "CeeDee Lamb"
+                assert result.picks[2].player.team == "DAL"
+                assert result.picks[2].player.position == "WR"
+                assert result.picks[2].owner == "Willow"
+
+                # Verify API calls were made
+                mock_get_draft.assert_called_once()
+                mock_get_players.assert_called_once()
+                assert mock_get_owner.call_count == 2  # Called for each unique owner
+
+
+@pytest.mark.asyncio
+async def test_tracker_parser_empty_draft():
+    """Test that tracker parser handles empty draft state gracefully."""
+    parser = TrackerDraftParser()
+
+    with patch.object(
+        parser.api_service, "get_draft_state", new_callable=AsyncMock
+    ) as mock_get_draft:
+        with patch.object(
+            parser.api_service, "get_all_players", new_callable=AsyncMock
+        ) as mock_get_players:
+
+            # Empty draft state
+            mock_get_draft.return_value = {"teams": [], "next_to_nominate": None}
+            mock_get_players.return_value = []
+
+            result = await parser.parse_draft_data([], None)
+
+            assert isinstance(result, DraftState)
+            assert len(result.teams) == 0
+            assert len(result.picks) == 0
+
+
+@pytest.mark.asyncio
+async def test_tracker_parser_missing_player():
+    """Test that tracker parser handles missing players gracefully."""
+    parser = TrackerDraftParser()
+
+    draft_state = {
+        "teams": [
+            {
+                "owner_id": 1,
+                "picks": [
+                    {
+                        "pick_id": 1,
+                        "player_id": 999999,
+                        "owner_id": 1,
+                    },  # Non-existent player
+                ],
+            }
+        ]
+    }
+
+    with patch.object(
+        parser.api_service, "get_draft_state", new_callable=AsyncMock
+    ) as mock_get_draft:
+        with patch.object(
+            parser.api_service, "get_all_players", new_callable=AsyncMock
+        ) as mock_get_players:
+            with patch.object(
+                parser.api_service, "get_owner_info", new_callable=AsyncMock
+            ) as mock_get_owner:
+
+                mock_get_draft.return_value = draft_state
+                mock_get_players.return_value = []  # No players
+                mock_get_owner.return_value = {
+                    "id": 1,
+                    "owner_name": "Spike",
+                    "team_name": "Big Bad Vamps",
+                }
+
+                result = await parser.parse_draft_data([], None)
+
+                # Should have team but no picks since player wasn't found
+                assert len(result.teams) == 1
+                assert len(result.picks) == 0
+
+
+@pytest.mark.asyncio
+async def test_tracker_parser_detect_format():
+    """Test that tracker parser's detect_format always returns True."""
+    parser = TrackerDraftParser()
+
+    # Should always return True since tracker format is explicitly configured
+    assert parser.detect_format([])
+    assert parser.detect_format([["some", "data"]])
+
+
+@pytest.mark.asyncio
+async def test_tracker_parser_with_custom_base_url():
+    """Test that tracker parser can be initialized with custom base URL."""
+    custom_url = "http://localhost:9999"
+    parser = TrackerDraftParser(base_url=custom_url)
+
+    assert parser.api_service.base_url == custom_url


### PR DESCRIPTION
The fantasy football draft assistant previously only supported draft tracking through Google Sheets, requiring users to manually update spreadsheets and configure Google API credentials. This implementation retrieves draft data from two different sheet formats: Dan format for snake drafts and Adam format for auction drafts, both requiring sheet parsing and Google authentication.

This change introduces a third data source option called "tracker" format that fetches real-time draft data directly from HTTP API endpoints instead of Google Sheets. The implementation adds a TrackerAPIService class that communicates with a draft tracking API, retrieving current draft state, owner information, and player details through RESTful endpoints. A TrackerDraftParser class implements the existing SheetParser interface to convert API responses into the same DraftState objects used by all MCP tools, ensuring complete compatibility with the existing tool ecosystem.

The goal is to provide users with a more dynamic and automated draft tracking option that eliminates the need for manual sheet updates and Google API configuration while maintaining the same data structure and tool functionality across all three supported formats.