### PR TITLE
(maint) Normalize defense positions for tracker compatibility

### DIFF
--- a/src/services/team_mapping.py
+++ b/src/services/team_mapping.py
@@ -102,3 +102,26 @@ def is_valid_team_abbreviation(team_abbrev: str) -> bool:
 
     valid_teams = get_all_valid_sheet_teams()
     return team_abbrev.upper() in valid_teams
+
+
+def normalize_position_for_rankings(position: str) -> str:
+    """
+    Normalize position string for rankings lookup.
+
+    Maps various defense position formats to the standard DST format
+    expected by the rankings scraper.
+
+    Args:
+        position: Position string from draft data (e.g., "D/ST", "DEF", "D")
+
+    Returns:
+        Normalized position string for rankings lookup
+    """
+    position_upper = position.upper().strip()
+
+    # Map defense variations to DST (which FantasySharks expects)
+    if position_upper in ["D/ST", "DEF", "D", "DST"]:
+        return "DST"
+
+    # Return other positions as-is
+    return position_upper

--- a/src/services/tracker_draft_parser.py
+++ b/src/services/tracker_draft_parser.py
@@ -8,6 +8,7 @@ from src.models.draft_state_simple import DraftState
 from src.models.injury_status import InjuryStatus
 from src.models.player_simple import Player
 from src.services.sheet_parser import ParseError, SheetParser
+from src.services.team_mapping import normalize_position_for_rankings
 from src.services.tracker_api_service import TrackerAPIService
 
 logger = logging.getLogger(__name__)
@@ -111,7 +112,9 @@ class TrackerDraftParser(SheetParser):
                     player = Player(
                         name=f"{player_info['first_name']} {player_info['last_name']}",
                         team=player_info["team"],
-                        position=player_info["position"],
+                        position=normalize_position_for_rankings(
+                            player_info["position"]
+                        ),
                         bye_week=0,  # Not available from tracker API
                         ranking=0,  # Not available from tracker API
                         projected_points=0.0,  # Not available from tracker API

--- a/tests/services/test_team_mapping.py
+++ b/tests/services/test_team_mapping.py
@@ -3,6 +3,7 @@
 from src.services.team_mapping import (
     get_all_valid_sheet_teams,
     is_valid_team_abbreviation,
+    normalize_position_for_rankings,
     normalize_team_abbreviation,
 )
 
@@ -136,3 +137,32 @@ class TestTeamMapping:
         # All expected teams should be in valid teams
         for team in expected_teams:
             assert team in valid_teams, f"Team {team} not found in valid teams"
+
+    def test_normalize_position_for_rankings(self):
+        """Test position normalization for rankings lookup."""
+        # Test defense position variations all map to DST
+        assert normalize_position_for_rankings("D/ST") == "DST"
+        assert normalize_position_for_rankings("DEF") == "DST"
+        assert normalize_position_for_rankings("D") == "DST"
+        assert normalize_position_for_rankings("DST") == "DST"
+
+        # Test case insensitive
+        assert normalize_position_for_rankings("d/st") == "DST"
+        assert normalize_position_for_rankings("def") == "DST"
+        assert normalize_position_for_rankings("d") == "DST"
+        assert normalize_position_for_rankings("dst") == "DST"
+
+        # Test with whitespace
+        assert normalize_position_for_rankings(" D/ST ") == "DST"
+        assert normalize_position_for_rankings("\tDEF\t") == "DST"
+
+        # Test other positions remain unchanged
+        assert normalize_position_for_rankings("QB") == "QB"
+        assert normalize_position_for_rankings("RB") == "RB"
+        assert normalize_position_for_rankings("WR") == "WR"
+        assert normalize_position_for_rankings("TE") == "TE"
+        assert normalize_position_for_rankings("K") == "K"
+
+        # Test case normalization for other positions
+        assert normalize_position_for_rankings("qb") == "QB"
+        assert normalize_position_for_rankings("rb") == "RB"


### PR DESCRIPTION
Previously, team defenses drafted through the tracker API used various position formats (D/ST, DEF, D) while FantasySharks rankings expected DST format. This mismatch prevented proper data correlation, resulting in missing bye week, ranking, and projected points data for drafted defense players.

This commit adds position normalization in team_mapping.py that standardizes all defense position variants to DST format. The normalization occurs when the tracker parser creates Player objects, ensuring consistent position formatting at the data source level and enabling proper matching with FantasySharks rankings data.